### PR TITLE
Fix map issue

### DIFF
--- a/app/src/main/java/com/openclassrooms/realestatemanager/ui/MapFragment.kt
+++ b/app/src/main/java/com/openclassrooms/realestatemanager/ui/MapFragment.kt
@@ -89,14 +89,20 @@ class MapFragment(
         val fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(requireActivity())
         fusedLocationProviderClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
             .addOnSuccessListener{ location ->
-                val latLng = LatLng(location.latitude, location.longitude)
-                googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 13.5F))
-                val agentMarker = this.agentMarker
-                agentMarker?.let { agentMarker.remove() }
-                this.agentMarker = googleMap.addMarker(MarkerOptions()
-                    .position(latLng)
-                    .icon(BitmapDescriptorFactory.fromResource(R.mipmap.icon_map_man))
-                    .title(getString(R.string.map_position_agent)))
+                if (isAdded) {
+                    val latLng = LatLng(location.latitude, location.longitude)
+                    googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 13.5F))
+                    val agentMarker = this.agentMarker
+                    agentMarker?.let { agentMarker.remove() }
+                    if (isAdded) {
+                        this.agentMarker = googleMap.addMarker(
+                            MarkerOptions()
+                                .position(latLng)
+                                .icon(BitmapDescriptorFactory.fromResource(R.mipmap.icon_map_man))
+                                .title(getString(R.string.map_position_agent))
+                        )
+                    }
+                }
             }
     }
 


### PR DESCRIPTION
Le bug se produisait en ouvrant le fragment map, puis en le remplaçant très vite par un autre fragment. Le fragment étant détaché de l'activité, l'accès au contexte est rompu, l'accès à getString(R. string.map_position_agent) ligne 100 en asynchrone crée un plantage de l'application.
La solution mis en place est l'ajout d'un test "if (isAdded)" sur le bloque de code.